### PR TITLE
reduce generated cpp file size.

### DIFF
--- a/src/bin2cpp.cpp
+++ b/src/bin2cpp.cpp
@@ -33,7 +33,7 @@ void outputCpp17(std::string &filename, std::fstream &file, std::string &filen, 
     outfile << "#define " << filen << "__H\n\n";
 
     outfile << R"STR(
-    #define BYTES(a,b,c,d,e,f,g,h) 0x##a,0x##b,0x##C,0x##d,0x##e,0x##f,0x##g,0x##h,
+    #define BYTES(a,b,c,d,e,f,g,h) 0x##a,0x##b,0x##c,0x##d,0x##e,0x##f,0x##g,0x##h,
     )STR";
 
     file.seekg(0, std::ios::end);
@@ -142,7 +142,7 @@ void outputCpp(std::string &filename, std::fstream &file, std::string &filen, st
     file.seekg(0, std::ios::beg);
 
     outfile << R"STR(
-    #define BYTES(a,b,c,d,e,f,g,h) 0x##a,0x##b,0x##C,0x##d,0x##e,0x##f,0x##g,0x##h,
+    #define BYTES(a,b,c,d,e,f,g,h) 0x##a,0x##b,0x##c,0x##d,0x##e,0x##f,0x##g,0x##h,
     )STR";
 
     outfile << "\nunsigned long " << filen << "_length = 0x" << std::hex << len << ";\n\n";

--- a/src/bin2cpp.cpp
+++ b/src/bin2cpp.cpp
@@ -73,7 +73,7 @@ void outputCpp17(std::string &filename, std::fstream &file, std::string &filen, 
         do{
             outfile << ",0";
         }while( ++ bytes_group_counter != 8);
-        outfile << "),";
+        outfile << ")";
     }
     
 
@@ -177,7 +177,7 @@ void outputCpp(std::string &filename, std::fstream &file, std::string &filen, st
         do{
             outfile << ",0";
         }while( ++ bytes_group_counter != 8);
-        outfile << "),";
+        outfile << ")";
     }
 
 

--- a/src/bin2cpp.cpp
+++ b/src/bin2cpp.cpp
@@ -33,7 +33,7 @@ void outputCpp17(std::string &filename, std::fstream &file, std::string &filen, 
     outfile << "#define " << filen << "__H\n\n";
 
     outfile << R"STR(
-    #define BYTES(a,b,c,d,e,f,g,h) 0x##a,0x##b,0x##C,0x##d,0x##e,0x##f,0x##g,
+    #define BYTES(a,b,c,d,e,f,g,h) 0x##a,0x##b,0x##C,0x##d,0x##e,0x##f,0x##g,0x##h,
     )STR";
 
     file.seekg(0, std::ios::end);
@@ -142,7 +142,7 @@ void outputCpp(std::string &filename, std::fstream &file, std::string &filen, st
     file.seekg(0, std::ios::beg);
 
     outfile << R"STR(
-    #define BYTES(a,b,c,d,e,f,g,h) 0x##a,0x##b,0x##C,0x##d,0x##e,0x##f,0x##g,
+    #define BYTES(a,b,c,d,e,f,g,h) 0x##a,0x##b,0x##C,0x##d,0x##e,0x##f,0x##g,0x##h,
     )STR";
 
     outfile << "\nunsigned long " << filen << "_length = 0x" << std::hex << len << ";\n\n";


### PR DESCRIPTION
use macro 
````
BYTES(1,2,a,b,c,d,e,f)
````

expand to 
````
0x1,0x2,0xa,0xb,0xc,0xd,0xe,0xf,
````
so generated file is smaller.

in my project, i convert a ttf file to cpp.  i reduce final cpp size from 64MB to 40MB.